### PR TITLE
SaveDump with bad characters

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/DumpEditor.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/DumpEditor.java
@@ -383,7 +383,8 @@ public class DumpEditor extends BasicActivity
         // Set a filename (UID + Date + Time) if there is none.
         if (mDumpName == null) {
             GregorianCalendar calendar = new GregorianCalendar();
-            SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss");
+            SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd_HHmmss", Locale.getDefault());
+            
             fmt.setCalendar(calendar);
             String dateFormatted = fmt.format(calendar.getTime());
             mDumpName = "UID_" + mUID + "_" + dateFormatted;


### PR DESCRIPTION
stackoverflow.com/questions/20310904/filename-chars-cause-opening-failed-einval-invalid-argument

Please refer to this page, you will find the full list.

http://en.wikipedia.org/wiki/Comparison_of_file_systems

Although that your sdcard might be internal and mount as FUSE, it might be still FAT32 filesystem. The valid characters for FAT32 are (according to the page):

Any byte except for values 0-31, 127 (DEL) and: " * / : < > ? \ | + , . ; = [] (lowcase a-z are stored as A-Z). With VFAT LFN any Unicode except NUL[14][15