### PR TITLE
Fixed crash for Android Marshmallow

### DIFF
--- a/Mifare Classic Tool/app/app.iml
+++ b/Mifare Classic Tool/app/app.iml
@@ -82,7 +82,7 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
   </component>
 </module>

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/FileChooser.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/FileChooser.java
@@ -262,10 +262,6 @@ public class FileChooser extends BasicActivity {
         RadioButton selected = (RadioButton) findViewById(
                 mGroupOfFiles.getCheckedRadioButtonId());
 
-        if (selected == null) {
-
-        }
-
         Intent intent = new Intent();
         File file = new File(mDir.getPath(), selected.getText().toString());
         intent.putExtra(EXTRA_CHOSEN_FILE, file.getPath());

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/FileChooser.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/FileChooser.java
@@ -18,9 +18,6 @@
 
 package de.syss.MifareClassicTool.Activities;
 
-import java.io.File;
-import java.util.Arrays;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -38,6 +35,10 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import java.io.File;
+import java.util.Arrays;
+
 import de.syss.MifareClassicTool.Common;
 import de.syss.MifareClassicTool.R;
 
@@ -260,6 +261,11 @@ public class FileChooser extends BasicActivity {
     public void onFileChosen(View view) {
         RadioButton selected = (RadioButton) findViewById(
                 mGroupOfFiles.getCheckedRadioButtonId());
+
+        if (selected == null) {
+
+        }
+
         Intent intent = new Intent();
         File file = new File(mDir.getPath(), selected.getText().toString());
         intent.putExtra(EXTRA_CHOSEN_FILE, file.getPath());
@@ -276,10 +282,12 @@ public class FileChooser extends BasicActivity {
      */
     private boolean updateFileIndex(File path) {
         File[] files = path.listFiles();
-        Arrays.sort(files);
-        mGroupOfFiles.removeAllViews();
+
         // Refresh file list.
-        if (files.length > 0) {
+        if (files != null && files.length > 0) {
+            Arrays.sort(files);
+            mGroupOfFiles.removeAllViews();
+
             for(File f : files) {
                 RadioButton r = new RadioButton(this);
                 r.setText(f.getName());

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/WriteTag.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/WriteTag.java
@@ -18,16 +18,6 @@
 
 package de.syss.MifareClassicTool.Activities;
 
-import java.io.File;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
@@ -40,8 +30,8 @@ import android.os.Handler;
 import android.util.SparseArray;
 import android.view.Gravity;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.View.OnClickListener;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -53,6 +43,17 @@ import android.widget.RadioButton;
 import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import de.syss.MifareClassicTool.Common;
 import de.syss.MifareClassicTool.MCReader;
 import de.syss.MifareClassicTool.R;
@@ -449,7 +450,7 @@ public class WriteTag extends BasicActivity {
         Intent intent = new Intent(this, KeyMapCreator.class);
         intent.putExtra(KeyMapCreator.EXTRA_KEYS_DIR,
                 Environment.getExternalStoragePublicDirectory(Common.HOME_DIR)
-                + "/" + Common.KEYS_DIR);
+                        + "/" + Common.KEYS_DIR);
         intent.putExtra(KeyMapCreator.EXTRA_SECTOR_CHOOSER, false);
         intent.putExtra(KeyMapCreator.EXTRA_SECTOR_CHOOSER_FROM, sector);
         intent.putExtra(KeyMapCreator.EXTRA_SECTOR_CHOOSER_TO, sector);

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/helpers/PermissionChecker.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/helpers/PermissionChecker.java
@@ -1,0 +1,16 @@
+package de.syss.MifareClassicTool.helpers;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.v4.content.ContextCompat;
+
+/**
+ * Created by mjurinic on 29.01.16..
+ */
+public final class PermissionChecker {
+
+    public static boolean hasWritePermission(Context context) {
+        return (ContextCompat.checkSelfPermission(context, android.Manifest.permission.WRITE_EXTERNAL_STORAGE)) ==
+                PackageManager.PERMISSION_GRANTED;
+    }
+}

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="action_save_keys">Save keys</string>
 
     <!-- Toast messages -->
+    <string name="info_write_permission">Application needs write permission.</string>
     <string name="info_new_tag_found">New tag found</string>
     <string name="info_no_external_storage">Error: External storage is not
         readable/writable</string>


### PR DESCRIPTION
The application was crashing on start after the update to Android 6 happened.

I added the new Marshmallow permission checks because the application wasn't able to write to external storeage, resulting in a NullPointerException.

When the application doesn't have write access all the buttons which are working with storage are muted until the user gives permission.

The code was tested on my HTC One M8.