### PR TITLE
MIFARE Classic Tool is working on OnePlus 3T

### DIFF
--- a/INCOMPATIBLE_DEVICES.md
+++ b/INCOMPATIBLE_DEVICES.md
@@ -69,3 +69,4 @@ This app **has been known to work** on the following devices.
 * Samsung Galaxy S3 Duo i9300i
 * Sony Xperia M4 Aqua
 * Sony Xperia V
+* OnePlus 3T


### PR DESCRIPTION
I testes the app on my OnePlus 3T. It's working as expected.