### PR TITLE
Fix missing google() maven repo in build.gradle

### DIFF
--- a/Mifare Classic Tool/build.gradle
+++ b/Mifare Classic Tool/build.gradle
@@ -2,6 +2,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'


### PR DESCRIPTION
Android Studio inserts it automatically but when using command line gradle it has to be added to the build.gradle file.

[F-Droid builds are failing because of this](https://gitlab.com/fdroid/fdroiddata/issues/1099).