### PR TITLE
Update INCOMPATIBLE_DEVICES.md

### DIFF
--- a/INCOMPATIBLE_DEVICES.md
+++ b/INCOMPATIBLE_DEVICES.md
@@ -66,7 +66,7 @@ This list may be incomplete. You might also want to have a look at
 * Samsung Galaxy S6 Edge Plus
 * Samsung Galaxy S7
 * Samsung Galaxy S7 Edge (some Versions)
-* Samsung Galaxy S8
+* Samsung Galaxy S8 (before update to Android 8)
 * Samsung Galaxy S8 Plus
 * Samsung Galaxy Xcover 3
 * Sony Xperia Z2 (some models)


### PR DESCRIPTION
It's interesting, but after update to Android Oreo Mifare Classic begins to work on S8 :)