### PR TITLE
Added an option to auto copy UID to clipboard.

### DIFF
--- a/Mifare Classic Tool/app/src/main/res/layout/activity_preferences.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_preferences.xml
@@ -208,6 +208,65 @@
 
             </RelativeLayout>
 
+            <RelativeLayout
+                android:id="@+id/relativeLayoutPreferencesCopyUID"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@xml/layout_border"
+                android:padding="2dp"
+                android:layout_marginBottom="5dp">
+
+                <CheckBox
+                    android:id="@+id/checkBoxPreferencesCopyUID"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_centerVertical="true"
+                    android:onClick="toggleUIDFormat"
+                    android:text="@string/action_auto_copy_uid" />
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/relativeLayoutPreferencesUIDFormat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@xml/layout_border"
+                android:padding="2dp"
+                android:layout_marginBottom="5dp">
+
+                <RadioGroup
+                    android:id="@+id/radioGroupUIDFormat"
+                    android:orientation="horizontal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="30dp">
+
+                    <RadioButton
+                        android:id="@+id/radioButtonHex"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:checked="true"
+                        android:text="Hex" />
+
+                    <RadioButton
+                        android:id="@+id/radioButtonDecBE"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Dec (BE)" />
+
+                    <RadioButton
+                        android:id="@+id/radioButtonDecLE"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Dec (LE)" />
+                </RadioGroup>
+
+            </RelativeLayout>
+
+
         </LinearLayout>
 
     </ScrollView>

--- a/Mifare Classic Tool/app/src/main/res/values-es/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values-es/strings.xml
@@ -185,6 +185,7 @@
         todos los sectores:</string>
     <string name="action_auto_reconnect">Avanzado: Auto reconectar si se
         pierde la etiqueta durante el proceso de mapeo de claves</string>
+    <string name="action_auto_copy_uid">Auto copiar UID en el portapapeles</string>
     <string name="action_save_last_key_files">Recordar los ficheros de claves
         seleccionados (diálogo de mapeo de claves)</string>
     <string name="action_save">Salvar</string>

--- a/Mifare Classic Tool/app/src/main/res/values-zh/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values-zh/strings.xml
@@ -4,6 +4,7 @@
     <string name="action_append">附加</string>
     <string name="ac_data_block_no_keyb_1"></string>
     <string name="action_auto_reconnect">高级: 在密钥映射时卡片丢失自动重连</string>
+    <string name="action_auto_copy_uid">UID复制到剪贴板</string>
     <string name="action_cancel">取消</string>
     <string name="action_cancel_all">取消写入</string>
     <string name="action_change">更改</string>

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -210,6 +210,7 @@
         to the internal storage</string>
     <string name="action_auto_reconnect">Advanced: Auto reconnect if tag gets
         lost during the key mapping process</string>
+    <string name="action_auto_copy_uid">Automatically copy new tag UID to clipboard</string>
     <string name="action_save_last_key_files">Remember the last selected key
         files (key mapping dialog)</string>
     <string name="action_use_custom_sector_count">Use custom sector count</string>


### PR DESCRIPTION
This fork adds a preference (disabled by default) allowing MCT to automatically copy the UID to clipboard as a decimal value each time a tag is scanned. In that case, the text of the toaster message will change to notify the user the value was copied to clipboard.

I needed this feature to replace an application called "Mifare ID Reader" by Nellon which would simply display the UID of a scanned tag in decimal format (I believe it was read as little endian). The application also had this little "Share" Floating Action Button. With that I could copy/paste the UID into a web app to look up the associated tag. Mifare ID Reader was not actively maintained and had some minor issues. About a month ago the app vanished from Google Play. I tried to contact the author to adopt the project, but got no response (it was not open source). For me, it's better to have just one tool that does everything I need. I wont be offended though if you consider this unnecessary bloat.