### PR TITLE
isKeyBReadable: Fix ordering of boolean operations

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Common.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Common.java
@@ -1005,9 +1005,9 @@ public class Common extends Application {
      */
     public static boolean isKeyBReadable(byte c1, byte c2, byte c3) {
         return c1 == 0
-                && (c2 == 0 && c3 == 0)
+                && ((c2 == 0 && c3 == 0)
                 || (c2 == 1 && c3 == 0)
-                || (c2 == 0 && c3 == 1);
+                || (c2 == 0 && c3 == 1));
     }
 
     /**


### PR DESCRIPTION
Otherwise I get an impossible access conditions decode