### PR TITLE
Added preference to open app on card detected

### DIFF
--- a/Mifare Classic Tool/app/src/main/AndroidManifest.xml
+++ b/Mifare Classic Tool/app/src/main/AndroidManifest.xml
@@ -48,16 +48,21 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
 
+        <activity-alias
+            android:targetActivity="de.syss.MifareClassicTool.Activities.MainMenu"
+            android:name=".MainMenuAlias"
+            android:label="@string/title_activity_main"
+            android:launchMode="singleTop" >
             <!-- NFC Tech Filter -->
             <intent-filter>
                 <action android:name="android.nfc.action.TECH_DISCOVERED" />
             </intent-filter>
-
             <meta-data
                 android:name="android.nfc.action.TECH_DISCOVERED"
                 android:resource="@xml/nfc_tech_filter" />
-        </activity>
+        </activity-alias>
 
         <!-- Content Providers -->
         <provider

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_preferences.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_preferences.xml
@@ -40,7 +40,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical" >
 
-           <RelativeLayout
+            <RelativeLayout
                 android:id="@+id/relativeLayoutPreferencesSaveLastUsedKeyFiles"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -256,6 +256,24 @@
                         android:layout_weight="1"
                         android:text="Dec (LE)" />
                 </RadioGroup>
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:id="@+id/relativeLayoutPreferencesAutostartWhenCardDetected"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginBottom="5dp"
+                android:background="@xml/layout_border"
+                android:padding="2dp">
+
+                <CheckBox
+                    android:id="@+id/checkBoxPreferencesAutostartWhenCardDetected"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentLeft="true"
+                    android:layout_centerVertical="true"
+                    android:text="@string/action_autostart_when_card_detected" />
 
             </RelativeLayout>
 

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
     <string name="action_auto_copy_uid">Automatically copy new tag UID to clipboard</string>
     <string name="action_save_last_key_files">Remember the last selected key
         files (key mapping dialog)</string>
+    <string name="action_autostart_when_card_detected">Autostart the app when a card is
+        detected</string>
     <string name="action_use_custom_sector_count">Use custom sector count</string>
     <string name="action_save">Save</string>
     <string name="action_share">Share</string>


### PR DESCRIPTION
Dear Ikarus, my team and I use your app frequently for our daly work.
For that reason we want to thank you by giving this community a solution to #97 issue: "add disable autostart option when card detected".
Our solution, that we use currently in one of our published apps, declares a main activity alias responsible for react on nfc event and disables/enables it using android package manager.
We hope you can review and accept this solution to a preferable feature like this!
