### PR TITLE
Add 7 Byte UID support to "Clone UID" tool

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/CloneUidTool.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/CloneUidTool.java
@@ -206,7 +206,7 @@ public class CloneUidTool extends BasicActivity {
         // Calculate BCC and cuonstruct full block 0.
         if (mUidLen == 7) {
             // 7 Byte UID cards don't seem to need stored BCC
-            mBlock0Complete = uid + mBlock0Rest7;
+            mBlock0Complete = uid + mBlock0Rest;
         } else {
             // Regular 4 byte UID
             byte bcc = Common.calcBCC(Common.hexStringToByteArray(uid));

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/CloneUidTool.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/CloneUidTool.java
@@ -121,6 +121,9 @@ public class CloneUidTool extends BasicActivity {
                     if (mUidLen == 7) {
                         m7ByteUid.setChecked(true);
                         mEditTextBlock0Rest.setText(mBlock0Rest7);
+                    } else if (mUidLen == 4) {
+                        m7ByteUid.setChecked(false);
+                        mEditTextBlock0Rest.setText(mBlock0Rest);
                     }
 
                     appendToLog(getString(

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/CloneUidTool.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/CloneUidTool.java
@@ -38,7 +38,7 @@ import de.syss.MifareClassicTool.R;
 /**
  * Clone UID to "magic tag gen2". The gen2 magic tags allow direct write to
  * block 0 without the need for special "backdoor" commands.
- * @author Slawomir Jasek slawomir.jasek@smartlockpicking.com and Gerhard Klostermeier
+ * @author Slawomir Jasek slawomir.jasek@smartlockpicking.com and Gerhard Klostermeier.
  * 7 Byte UID support by Donny Maasland
  */
 public class CloneUidTool extends BasicActivity {
@@ -203,7 +203,7 @@ public class CloneUidTool extends BasicActivity {
         // Calculate BCC and cuonstruct full block 0.
         if (mUidLen == 7) {
             // 7 Byte UID cards don't seem to need stored BCC
-            mBlock0Complete = uid + mBlock0Rest;
+            mBlock0Complete = uid + mBlock0Rest7;
         } else {
             // Regular 4 byte UID
             byte bcc = Common.calcBCC(Common.hexStringToByteArray(uid));

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_clone_uid_tool.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_clone_uid_tool.xml
@@ -89,7 +89,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:hint="@string/hint_hex_4_byte"
+                android:hint="@string/hint_hex_4_or_7_byte"
                 android:imeOptions="actionDone"
                 android:inputType="textCapCharacters|textNoSuggestions"
                 android:maxLength="14" />

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_clone_uid_tool.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_clone_uid_tool.xml
@@ -105,10 +105,18 @@
         </LinearLayout>
 
         <CheckBox
-            android:id="@+id/checkBoxCloneUidToolOptions"
+            android:id="@+id/checkBoxCloneUidTool7Byte"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/linearLayoutCloneUidToolToClone"
+            android:onClick="on7ByteUid"
+            android:text="@string/action_7byte_uid" />
+
+        <CheckBox
+            android:id="@+id/checkBoxCloneUidToolOptions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/checkBoxCloneUidTool7Byte"
             android:onClick="onShowOptions"
             android:text="@string/action_show_options" />
 

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -222,6 +222,7 @@
     <string name="action_write_mfid">Advanced: Enable writing to
         manufacturer block</string>
     <string name="action_show_options">Show Options</string>
+    <string name="action_7byte_uid">7-Byte UID</string>
     <string name="action_static_ac">Use these Access Conditions for all
         sectors:</string>
     <string name="action_retry_authentication">Retry the authentication if it fails</string>

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -575,7 +575,7 @@
         This App is able to write to such tags and can therefore clone the UID. However, some special
         tags (\"magic tags 1st gen\") require a special command sequence to put them into the
         state where writing to the manufacturer block is possible. These tags will not work.
-        \n\nFor now this tool will only work with 4-byte UIDs.</string>
+        \n\nFor now this tool will only work with 4-byte and 7-byte UIDs.</string>
     <string name="dialog_rest_of_block_0_title">Rest of Block 0</string>
     <string name="dialog_rest_of_block_0">MIFARE Classic tags can typically only be
         written blockwise. The UID is represented by the first bytes of block 0. To

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -590,6 +590,7 @@
     <string name="hint_hex_16_byte">HEX, 16 bytes (e.g. 0A4F&#8230;)</string>
     <string name="hint_hex_3_byte">HEX, 3 bytes</string>
     <string name="hint_hex_4_byte">HEX, 4 bytes</string>
+    <string name="hint_hex_4_or_7_byte">HEX, 4 or 7 bytes</string>
     <string name="hint_hex_00">00</string>
     <string name="hint_int_423">e.g. 423</string>
     <string name="hint_custom_sector_count">e.g. 16 for 1K</string>


### PR DESCRIPTION
Hello,

This is my first attempt to contribute to the project so go easy on me :). I've tried adding support for 7 Byte UID cards to the "Clone UID" tool. The changes I made seem to work for 7 Byte UID gen 2 magic cards. The new block 0 is written and the UID is changed.

I wasn't able to test this with 4 byte UID cards as I have no gen 2 magic cards with 4 byte UID's.

The only thing I wasn't able to do was add a translation for the "7 Byte UID" string. I hope that's okay.

I am not in any way a Java programmer so I'm open to any suggestions and improvements.

Thanks!