### PR TITLE
Make NFC optional

### DIFF
--- a/Mifare Classic Tool/app/src/main/AndroidManifest.xml
+++ b/Mifare Classic Tool/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
 
     <uses-feature
         android:name="android.hardware.nfc"
-        android:required="true" />
+        android:required="false" />
 
 
 


### PR DESCRIPTION
As this app supports external NFC readers, it should be possible to find it on Google Play.
