### PR TITLE
Add Hide Identical Sectors option and show Difference Percentage

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/DiffTool.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/DiffTool.java
@@ -27,6 +27,7 @@ import android.os.Bundle;
 import android.util.SparseArray;
 import android.view.View;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -59,6 +60,7 @@ public class DiffTool extends BasicActivity {
     private LinearLayout mDiffContent;
     private Button mDumpFileButton1;
     private Button mDumpFileButton2;
+    private CheckBox mDumpHideIdentical;
     private SparseArray<String[]> mDump1;
     private SparseArray<String[]> mDump2;
 
@@ -74,6 +76,7 @@ public class DiffTool extends BasicActivity {
         mDiffContent = findViewById(R.id.linearLayoutDiffTool);
         mDumpFileButton1 = findViewById(R.id.buttonDiffToolDump1);
         mDumpFileButton2 = findViewById(R.id.buttonDiffToolDump2);
+        mDumpHideIdentical = findViewById(R.id.checkBoxDiffToolHideIdentical);
 
         // Check if one or both dumps are already chosen via Intent
         // (from DumpEditor).
@@ -143,6 +146,21 @@ public class DiffTool extends BasicActivity {
                 if (blocks == null) {
                     // No such sector.
                     continue;
+                }
+
+                // If the Hide Identical Sectors is checked,
+                // Do not display the same sector.
+                if (mDumpHideIdentical.isChecked() && blocks.length > 1) {
+                    int block;
+                    for (block = 0; block < blocks.length; block++) {
+                        if (blocks[block].length != 0) {
+                            break;
+                        }
+                    }
+                    if (block == blocks.length) {
+                        // Identical sector.
+                        continue;
+                    }
                 }
 
                 // Add sector header.
@@ -239,6 +257,14 @@ public class DiffTool extends BasicActivity {
     public void onChooseDump2(View view) {
         Intent intent = prepareFileChooserForDump();
         startActivityForResult(intent, FILE_CHOOSER_DUMP_FILE_2);
+    }
+
+    /**
+     * Run diff if the Hide Identical Sectors option is changed.
+     * @see #runDiff()
+     */
+    public void onHideIdenticalChanged(View view) {
+        runDiff();
     }
 
     /**

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_diff_tool.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_diff_tool.xml
@@ -37,8 +37,8 @@
             android:id="@+id/buttonDiffToolDump1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
             android:layout_alignParentRight="true"
+            android:layout_alignParentTop="true"
             android:layout_toRightOf="@+id/textViewDiffToolDump1"
             android:gravity="left|center_vertical"
             android:onClick="onChooseDump1"
@@ -59,12 +59,9 @@
             android:id="@+id/buttonDiffToolDump2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/buttonDiffToolDump1"
             android:layout_alignLeft="@+id/buttonDiffToolDump1"
             android:layout_alignParentRight="true"
-            android:layout_marginLeft="2dp"
-            android:layout_marginTop="0dp"
-            android:layout_marginRight="-1dp"
+            android:layout_below="@+id/buttonDiffToolDump1"
             android:gravity="left|center_vertical"
             android:onClick="onChooseDump2"
             android:text="@string/action_chose_dump" />
@@ -110,7 +107,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:orientation="vertical">
+            android:orientation="vertical" >
 
         </LinearLayout>
 

--- a/Mifare Classic Tool/app/src/main/res/layout/activity_diff_tool.xml
+++ b/Mifare Classic Tool/app/src/main/res/layout/activity_diff_tool.xml
@@ -19,56 +19,76 @@
 -->
 
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/relativeLayoutDiffTool"
+    android:id="@+id/linearLayoutDiffToolTop"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="5dp"
+    android:orientation="vertical"
     tools:context="Activities.DiffTool" >
 
-    <Button
-        android:id="@+id/buttonDiffToolDump1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
-        android:layout_toRightOf="@+id/textViewDiffToolDump1"
-        android:gravity="left|center_vertical"
-        android:onClick="onChooseDump1"
-        android:text="@string/action_chose_dump" />
+    <RelativeLayout
+        android:id="@+id/relativeLayoutDiffTool"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/textViewDiffToolDump1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignBaseline="@+id/buttonDiffToolDump1"
-        android:layout_alignBottom="@+id/buttonDiffToolDump1"
-        android:layout_alignParentLeft="true"
-        android:paddingRight="5dp"
-        android:text="@string/text_dump_1"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        <Button
+            android:id="@+id/buttonDiffToolDump1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentRight="true"
+            android:layout_toRightOf="@+id/textViewDiffToolDump1"
+            android:gravity="left|center_vertical"
+            android:onClick="onChooseDump1"
+            android:text="@string/action_chose_dump" />
 
-    <Button
-        android:id="@+id/buttonDiffToolDump2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignLeft="@+id/buttonDiffToolDump1"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/buttonDiffToolDump1"
-        android:gravity="left|center_vertical"
-        android:onClick="onChooseDump2"
-        android:text="@string/action_chose_dump" />
+        <TextView
+            android:id="@+id/textViewDiffToolDump1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBaseline="@+id/buttonDiffToolDump1"
+            android:layout_alignBottom="@+id/buttonDiffToolDump1"
+            android:layout_alignParentLeft="true"
+            android:paddingRight="5dp"
+            android:text="@string/text_dump_1"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <TextView
-        android:id="@+id/textViewDiffToolDump2"
-        android:layout_width="wrap_content"
+        <Button
+            android:id="@+id/buttonDiffToolDump2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/buttonDiffToolDump1"
+            android:layout_alignLeft="@+id/buttonDiffToolDump1"
+            android:layout_alignParentRight="true"
+            android:layout_marginLeft="2dp"
+            android:layout_marginTop="0dp"
+            android:layout_marginRight="-1dp"
+            android:gravity="left|center_vertical"
+            android:onClick="onChooseDump2"
+            android:text="@string/action_chose_dump" />
+
+        <TextView
+            android:id="@+id/textViewDiffToolDump2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBaseline="@+id/buttonDiffToolDump2"
+            android:layout_alignBottom="@+id/buttonDiffToolDump2"
+            android:layout_alignParentLeft="true"
+            android:paddingRight="5dp"
+            android:text="@string/text_dump_2"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+    </RelativeLayout>
+
+    <CheckBox
+        android:id="@+id/checkBoxDiffToolHideIdentical"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignBaseline="@+id/buttonDiffToolDump2"
-        android:layout_alignBottom="@+id/buttonDiffToolDump2"
-        android:layout_alignParentLeft="true"
-        android:paddingRight="5dp"
-        android:text="@string/text_dump_2"
+        android:onClick="onHideIdenticalChanged"
+        android:paddingTop="5dp"
+        android:paddingBottom="5dp"
+        android:text="@string/action_hide_identical_sectors"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <!-- Separator -->
@@ -78,27 +98,22 @@
         android:layout_height="2dp"
         android:layout_marginTop="5dp"
         android:layout_marginBottom="5dp"
-        android:layout_below="@+id/buttonDiffToolDump2"
         android:background="@color/light_gray" />
 
     <ScrollView
         android:id="@+id/scrollViewDiffTool"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentRight="true"
-        android:layout_below="@+id/separatorDiffTool" >
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:id="@+id/linearLayoutDiffTool"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:orientation="vertical" >
+            android:orientation="vertical">
 
         </LinearLayout>
 
     </ScrollView>
 
-</RelativeLayout>
+</LinearLayout>

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
             to 4.0.0? Please read section \"1.2 Data Storage\" of \"Help and Info\".</string>
     <string name="text_more_converter">More converter (online)</string>
     <string name="text_enter_file_name">Enter a file name</string>
+    <string name="text_difference_between_dumps">Difference between dumps</string>
 
     <!-- Actions (Buttons, Checkboxs, etc. -->
     <string name="action_read_tag">Read Tag</string>

--- a/Mifare Classic Tool/app/src/main/res/values/strings.xml
+++ b/Mifare Classic Tool/app/src/main/res/values/strings.xml
@@ -310,6 +310,7 @@
     <string name="action_multi_purpose_converter">Multi-Purpose Converter</string>
     <string name="action_cyber_chef">Cyber Chef</string>
     <string name="action_open_clone_uid_tool">Open the Clone UID Tool</string>
+    <string name="action_hide_identical_sectors">Hide identical sectors</string>
 
     <!-- Toast messages -->
     <string name="info_new_tag_found">New tag found</string>


### PR DESCRIPTION
This PR implements #414

1. Add Hide Identical Sectors option in Diff Tool.
2. Show difference between dumps in Diff Tool.

In the picture below, sectors 1 to 14 are identical and therefore not shown.
The difference was calculated as 21 / 2048 ≒ 1.03%.
For reference, 21 is the number of 'X', and a typical 1KB card is 2048 bytes in HEX string.

![test](https://github.com/ikarus23/MifareClassicTool/assets/54697735/a79615be-d61d-44b6-9afa-a0eb158a713f)
