### PR TITLE
fix Cancel Create Key Map in MCReader

### DIFF
--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/KeyMapCreator.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/Activities/KeyMapCreator.java
@@ -142,6 +142,7 @@ public class KeyMapCreator extends BasicActivity {
     private File mKeyDirPath;
     private int mFirstSector;
     private int mLastSector;
+    private MCReader currentReader;
 
     /**
      * Set layout, set the mapping range
@@ -331,6 +332,9 @@ public class KeyMapCreator extends BasicActivity {
     public void onCancelCreateKeyMap(View view) {
         if (mIsCreatingKeyMap) {
             mIsCreatingKeyMap = false;
+            if (currentReader != null) {
+                currentReader.cancelCreateKeyMap();
+            }
             mCancel.setEnabled(false);
         } else {
             finish();
@@ -395,6 +399,7 @@ public class KeyMapCreator extends BasicActivity {
 
                 // Create reader.
                 MCReader reader = Common.checkForTagAndCreateReader(this);
+                currentReader = reader;
                 if (reader == null) {
                     return;
                 }

--- a/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/MCReader.java
+++ b/Mifare Classic Tool/app/src/main/java/de/syss/MifareClassicTool/MCReader.java
@@ -65,6 +65,7 @@ public class MCReader {
     private int mFirstSector = 0;
     private ArrayList<String> mKeysWithOrder;
     private boolean mHasAllZeroKey = false;
+    private boolean cancelCreateKeyMap = false;
 
     /**
      * Initialize a MIFARE Classic reader for the given tag.
@@ -105,6 +106,10 @@ public class MCReader {
             }
         }
         return mcr;
+    }
+
+    public void cancelCreateKeyMap() {
+        cancelCreateKeyMap = true;
     }
 
     /**
@@ -460,6 +465,7 @@ public class MCReader {
     public int buildNextKeyMapPart() {
         // Clear status and key map before new walk through sectors.
         boolean error = false;
+        cancelCreateKeyMap = false;
         if (mKeysWithOrder != null && mLastSector != -1) {
             if (mKeyMapStatus == mLastSector+1) {
                 mKeyMapStatus = mFirstSector;
@@ -487,6 +493,9 @@ public class MCReader {
                 byte[] bytesKey = Common.hex2Bytes(key);
                 for (int j = 0; j < retryAuthCount+1;) {
                     try {
+                        if (cancelCreateKeyMap) {
+                            return -1;
+                        }
                         if (!foundKeys[0]) {
                             auth = mMFC.authenticateSectorWithKeyA(
                                     mKeyMapStatus, bytesKey);


### PR DESCRIPTION
In **Read Tag**, clicking on **Cancel** after **Start Mapping and read tag** can take several seconds before the App is available to start another mapping. This is due to the high number of keys being tried in `MCReader`.

This fix propagates the **Cancel** request to `MCReader` and exit the for loops in `buildNextKeyMapPart()`.

### Step to reproduce:
- Navigate to the Read Tag Screen
- select all key files
- Click **Start Mapping and read tag**
- Click **Cancel** 

### Old behavior:
Cancel can take several seconds to complete

### New behavior:
Cancel resolves immediately

![Screenshot_20240512_231958](https://github.com/ikarus23/MifareClassicTool/assets/37911979/8f7ac0f0-3e5e-4534-abe0-bfe9e528b9fa)
