### PR TITLE
Update COMPATIBLE_DEVICES.md

### DIFF
--- a/COMPATIBLE_DEVICES.md
+++ b/COMPATIBLE_DEVICES.md
@@ -21,6 +21,7 @@ hardware (NFC-controller) does support MIFARE Classic
 * Google Pixel 3a XL
 * Google Pixel 4a
 * Google Pixel 5a
+* Google Pixel 6 Pro
 * Google Pixel 7
 * Honor 9
 * Honor 10


### PR DESCRIPTION
Works with my Google Pixel 6 Pro flawlessly.

Strangely my Note 10+ can't scan some 14443A tags which my pixel was scanning just fine.