### PR TITLE
Add Pixel 6a & Pixel 8a to COMPATIBLE_DEVICES.md

### DIFF
--- a/COMPATIBLE_DEVICES.md
+++ b/COMPATIBLE_DEVICES.md
@@ -22,10 +22,10 @@ hardware (NFC-controller) does support MIFARE Classic
 * Google Pixel 4a
 * Google Pixel 5a
 * Google Pixel 6a
-* Google Pixel 8a
 * Google Pixel 6 Pro
 * Google Pixel 7
 * Google Pixel 8 / 8 Pro (Android 15+)
+* Google Pixel 8a
 * Honor 9
 * Honor 10
 * HTC One

--- a/COMPATIBLE_DEVICES.md
+++ b/COMPATIBLE_DEVICES.md
@@ -21,6 +21,8 @@ hardware (NFC-controller) does support MIFARE Classic
 * Google Pixel 3a XL
 * Google Pixel 4a
 * Google Pixel 5a
+* Google Pixel 6a
+* Google Pixel 8a
 * Google Pixel 6 Pro
 * Google Pixel 7
 * Google Pixel 8 / 8 Pro (Android 15+)

--- a/COMPATIBLE_DEVICES.md
+++ b/COMPATIBLE_DEVICES.md
@@ -21,8 +21,8 @@ hardware (NFC-controller) does support MIFARE Classic
 * Google Pixel 3a XL
 * Google Pixel 4a
 * Google Pixel 5a
-* Google Pixel 6a
 * Google Pixel 6 Pro
+* Google Pixel 6a
 * Google Pixel 7
 * Google Pixel 8 / 8 Pro (Android 15+)
 * Google Pixel 8a


### PR DESCRIPTION
I've tested both the Pixel 6a and Pixel 8a with the Metrodroid app.